### PR TITLE
Fix link confirmation and button activation

### DIFF
--- a/PASTE_LINK_ISSUE_FIX.md
+++ b/PASTE_LINK_ISSUE_FIX.md
@@ -1,0 +1,73 @@
+# Paste Link Issue Fix Report
+
+## Problem Description
+Users were unable to paste links into the form for adding new places/cards. The submit button remained disabled even after pasting valid URLs, making it impossible to submit the form.
+
+## Root Cause
+The validation system in `scripts/validate.js` only listened for `input` events to trigger form validation and button state changes. When users paste content into input fields, the `input` event doesn't always trigger consistently across all browsers, leaving the button in a disabled state.
+
+## Technical Details
+- Submit button has `popup__button-submit_disabled` class which:
+  - Makes it visually grayed out
+  - Disables pointer events (`pointer-events: none`)
+  - Sets the `disabled` attribute
+- The `toggleButtonState` function controls button activation based on form validity
+- Only `input` events were triggering validation checks
+
+## Solution Implemented
+
+### 1. Enhanced Event Listeners (`scripts/validate.js`)
+Added multiple event listeners to capture all user input methods:
+- `paste` event with 10ms timeout to ensure pasted content is processed
+- `change` event for input field changes
+- `keyup` event for keyboard input
+- Existing `input` event maintained for compatibility
+
+### 2. Improved Form Reset Logic (`scripts/index.js`)
+Added proper form state management:
+- Clear form inputs when popup opens
+- Reset form after successful submission
+- Clear error messages
+- Reset button to disabled state
+
+## Code Changes
+
+### `scripts/validate.js`
+```javascript
+// Added multiple event listeners for comprehensive input detection
+inputElement.addEventListener("input", handleInputChange);
+inputElement.addEventListener("paste", (evt) => {
+    setTimeout(() => {
+        checkInputValidity(formElement, inputElement);
+        toggleButtonState(inputList, buttonElement);
+    }, 10);
+});
+inputElement.addEventListener("change", handleInputChange);
+inputElement.addEventListener("keyup", handleInputChange);
+```
+
+### `scripts/index.js`
+```javascript
+// Added form reset logic when opening popup and after submission
+popupPlusTitle.value = '';
+popupPlusLink.value = '';
+popupAllErrors.forEach(error => {
+    error.textContent = '';
+    error.classList.remove('popup__display-error_active');
+});
+popupPlusCreate.classList.add('popup__button-submit_disabled');
+popupPlusCreate.setAttribute('disabled', true);
+```
+
+## Result
+- Users can now paste links into the form and the submit button will activate correctly
+- Form validation works consistently across all input methods
+- Better user experience with proper form state management
+- Clean form state on each use
+
+## Testing
+Start the development server with `python3 -m http.server 8000` and test:
+1. Open the "Add Place" form
+2. Paste a valid URL into the image link field
+3. Enter a title
+4. Verify the submit button becomes active and clickable

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -133,6 +133,20 @@ const popupPlusCreate = document.querySelector('.popup-add-button__add-button-cr
 const popupPlusContents = document.querySelector('.popup-add-button__add-main');
 
 popupPlusButton.addEventListener('click', () => {
+    // Clear form inputs
+    popupPlusTitle.value = '';
+    popupPlusLink.value = '';
+    
+    // Clear any error messages
+    popupAllErrors.forEach(error => {
+        error.textContent = '';
+        error.classList.remove('popup__display-error_active');
+    });
+    
+    // Reset button state
+    popupPlusCreate.classList.add('popup__button-submit_disabled');
+    popupPlusCreate.setAttribute('disabled', true);
+    
     openPopupToggle(popupMainPlusButton)
 });
 popupPlusClose.addEventListener('click', () => {
@@ -149,6 +163,20 @@ popupPlusContents.addEventListener('submit', (evt) => {
 
     const detailCard = getCardElement(coverCard)
     cardsContainer.prepend(detailCard);
+
+    // Reset form after successful submission
+    popupPlusTitle.value = '';
+    popupPlusLink.value = '';
+    
+    // Clear any error messages
+    popupAllErrors.forEach(error => {
+        error.textContent = '';
+        error.classList.remove('popup__display-error_active');
+    });
+    
+    // Reset button state
+    popupPlusCreate.classList.add('popup__button-submit_disabled');
+    popupPlusCreate.setAttribute('disabled', true);
 
     openPopupToggle(popupMainPlusButton)
 });

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -129,10 +129,21 @@ const setEventListeners = (formElement) => {
     const buttonElement = formElement.querySelector(".popup__button-submit");
 
     inputList.forEach((inputElement) => {
-        inputElement.addEventListener("input", () => {
+        const handleInputChange = () => {
             checkInputValidity(formElement, inputElement);
             toggleButtonState(inputList, buttonElement);
+        };
+
+        inputElement.addEventListener("input", handleInputChange);
+        inputElement.addEventListener("paste", (evt) => {
+            // Use setTimeout to ensure the pasted content is processed
+            setTimeout(() => {
+                checkInputValidity(formElement, inputElement);
+                toggleButtonState(inputList, buttonElement);
+            }, 10);
         });
+        inputElement.addEventListener("change", handleInputChange);
+        inputElement.addEventListener("keyup", handleInputChange);
     });
 
     toggleButtonState(inputList, buttonElement);


### PR DESCRIPTION
Enhance form validation to activate submit button after pasting links and improve form reset logic.

The previous validation system only listened for `input` events, which are not consistently triggered by paste operations across all browsers. This led to the submit button remaining disabled even after valid content was pasted. The changes add more robust event listeners (`paste`, `change`, `keyup`) and ensure the form state is correctly managed on open and submit.